### PR TITLE
Hotfix: Update es_mx.json

### DIFF
--- a/common/src/main/resources/assets/labels/lang/es_mx.json
+++ b/common/src/main/resources/assets/labels/lang/es_mx.json
@@ -1,4 +1,4 @@
 {
-  "entity.labels.label": "Etiqueta",
-  "item.labels.label": "Etiqueta"
+  "entity.labels.label": "Cartel",
+  "item.labels.label": "Cartel"
 }


### PR DESCRIPTION
- changed Etiqueta to Cartel to avoid being equal to the Name Tag translation.

sorry for PR this again, didn't notice the error.